### PR TITLE
Retry on conflict param for connectror

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -345,6 +345,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.SHORT,
         "Create indices at startup"
+    ).define(
+        RETRY_ON_CONFLICT_CONFIG,
+        Type.INT,
+        0,
+        Importance.LOW,
+        RETRY_ON_CONFLICT_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Retry on conflict"
     );
   }
 
@@ -471,17 +481,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         group,
         ++order,
         Width.SHORT,
-        "Write method"
-    ).define(
-        RETRY_ON_CONFLICT_CONFIG,
-        Type.INT,
-        0,
-        Importance.LOW,
-        RETRY_ON_CONFLICT_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Retry on conflict");
+        "Write method");
   }
 
   public static final ConfigDef CONFIG = baseConfigDef();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -166,6 +166,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "increasing the " + FLUSH_TIMEOUT_MS_CONFIG + ", " + READ_TIMEOUT_MS_CONFIG
           + ", and decrease " + BATCH_SIZE_CONFIG + " configuration properties.";
 
+  public static final String RETRY_ON_CONFLICT_CONFIG = "retry.on.conflict";
+  private static final String RETRY_ON_CONFLICT_DOC = "Specify how many times the operation "
+      + "should be retried by Elasticsearch, when conflicts occur, while using the write method "
+      + WriteMethod.UPSERT.toString() + ". The value is the number of retries.";
+
   public static final String CONNECTION_SSL_CONFIG_PREFIX = "elastic.https.";
 
   public static final String AUTO_CREATE_INDICES_AT_START_CONFIG = "auto.create.indices.at.start";
@@ -466,7 +471,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         group,
         ++order,
         Width.SHORT,
-        "Write method");
+        "Write method"
+    ).define(
+        RETRY_ON_CONFLICT_CONFIG,
+        Type.INT,
+        0,
+        Importance.LOW,
+        RETRY_ON_CONFLICT_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Retry on conflict");
   }
 
   public static final ConfigDef CONFIG = baseConfigDef();

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -90,6 +90,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   private final JestClient client;
   private final Version version;
   private WriteMethod writeMethod = WriteMethod.DEFAULT;
+  private int retryOnConflict;
 
   private final Set<String> indexCache = new HashSet<>();
 
@@ -142,6 +143,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       this.version = getServerVersion();
       this.writeMethod = WriteMethod.forValue(
               config.getString(ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG));
+      this.retryOnConflict = config.getInt(
+          ElasticsearchSinkConnectorConfig.RETRY_ON_CONFLICT_CONFIG);
     } catch (IOException e) {
       throw new ConnectException(
           "Couldn't start ElasticsearchSinkTask due to connection error:",
@@ -455,11 +458,14 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   private Update toUpdateRequest(IndexableRecord record) {
     String payload = "{\"doc\":" + record.payload
         + ", \"doc_as_upsert\":true}";
-    return new Update.Builder(payload)
+    Update.Builder req = new Update.Builder(payload)
         .index(record.key.index)
         .type(record.key.type)
-        .id(record.key.id)
-        .build();
+        .id(record.key.id);
+    if (retryOnConflict > 0) {
+      req.setParameter("retry_on_conflict", retryOnConflict);
+    }
+    return req.build();
   }
 
   public BulkResponse executeBulk(BulkRequest bulk) throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
@@ -33,7 +33,13 @@ import io.searchbox.client.JestResult;
 import io.searchbox.client.config.ElasticsearchVersion;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.cluster.NodesInfo;
-import io.searchbox.core.*;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.Delete;
+import io.searchbox.core.DocumentResult;
+import io.searchbox.core.Index;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.core.Update;
 import io.searchbox.indices.CreateIndex;
 import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.mapping.GetMapping;
@@ -371,7 +377,7 @@ public class JestElasticsearchClientTest {
   }
 
   @Test
-  public void retryOnConflict() throws Exception {
+  public void retryOnConflictParameterIsPresent() throws Exception {
     Map<String, String> props = new HashMap<>();
     props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost:9200");
     props.put(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG, "kafka-connect");


### PR DESCRIPTION
This PR introduces a param `retry.on.conflict` that specifies how many times the operation should be retried by Elasticsearch, when conflicts occur, while using the write method.

https://github.com/confluentinc/kafka-connect-elasticsearch/pull/384/files